### PR TITLE
fix bower.json 'main' entry so it can be used with grunt task bower-inst...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Arun Israel <arun.israel@gmail.com>"
   ],
   "description": "An angular.js wrapper around window.navigator.geolocation",
-  "main": "geolocation.js",
+  "main": "./src/geolocation.js",
   "keywords": [
     "geolocation",
     "angular.js"


### PR DESCRIPTION
This fixes the 'main' entry in bower.json to point correctly to the geolocation.js file.
This is specially important when using the 'bower-install' grunt task, as it uses this information to embedd the script tags on the html.
