### PR TITLE
Use JS Formatting in code blocks, add whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An angular.js wrapper around window.navigator.geolocation
 
 Bower
 --
+
 This module is available as bower package, install it with this command:
 
 ```bash
@@ -18,6 +19,7 @@ bower install git://github.com/arunisrael/angularjs-geolocation.git
 
 Usage
 --
+
 - Add the geolocation module as dependency
 - Inject the geolocation service (yes, it has the same name)
 - Invoke the getLocation method on the geolocation service to retrieve a promise
@@ -26,7 +28,8 @@ Usage
 
 Example
 --
-```
+
+```js
 angular.module('barterApp',['geolocation'])
   .controller('geoCtrl', function ($scope,geolocation) {
     geolocation.getLocation().then(function(data){
@@ -37,26 +40,32 @@ angular.module('barterApp',['geolocation'])
 
 Demo
 --
+
 See this [plunker](http://embed.plnkr.co/TM71LBh6ttYotOo6t7oX/preview) that displays your latitude/longitude
 
 Error Handling
 --
+
 The geolocation module defines a geolocation-msgs constant holding error msgs that are broadcast if the user rejects location access:
-```
+
+```js
 $rootScope.$broadcast('error',CONSTANTS['errors.location.notFound']);
 ```
 
 or if the browser does not support geolocation:
-```
+
+```js
 $rootScope.$broadcast('error',geolocation_msgs['errors.location.unsupportedBrowser']);
 ```
 
 Testing
 --
+
 ```
 grunt test
 ```
 
 License
 --
-MIT
+
+[The MIT License](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
Use ```js in Javascript code blocks.

Add whitespace after headers in the Markdown. It doesn't affect the presentation, but it makes reading the Markdown a little more easy.

Link to the MIT license.
