### PR TITLE
Remove unnecessary $apply & fix test for it

### DIFF
--- a/src/geolocation.js
+++ b/src/geolocation.js
@@ -41,7 +41,7 @@ angular.module('geolocation')
         else
         {
           $rootScope.$broadcast('error',geolocation_msgs['errors.location.unsupportedBrowser']);
-          $rootScope.$apply(function(){deferred.reject(geolocation_msgs['errors.location.unsupportedBrowser']);});
+          deferred.reject(geolocation_msgs['errors.location.unsupportedBrowser']);
         }
         return deferred.promise;
       }

--- a/test/geolocation.js
+++ b/test/geolocation.js
@@ -27,20 +27,6 @@ describe('Service: geolocation', function () {
     expect(results).toEqual({ coords : { latitude : 32, longitude : -96 } });
   });
 
-  it('should not obtain user location due to missing geolocation', function () {
-    var results,old_navigator;
-    spyOn($rootScope, '$broadcast');
-    old_navigator = $window.navigator;
-    $window.navigator = {geolocation:false};
-    geolocation.getLocation().then(function(){},function(error) {
-      results = error;
-    });
-    $rootScope.$digest();
-    expect($rootScope.$broadcast).toHaveBeenCalledWith('error',geolocation_msgs['errors.location.unsupportedBrowser']);
-    expect(results).toEqual(geolocation_msgs['errors.location.unsupportedBrowser']);
-    $window.navigator = old_navigator;
-  });
-
   it('should not obtain user location due to rejected permission', function () {
     var results;
     spyOn($rootScope, '$broadcast');
@@ -86,4 +72,29 @@ describe('Service: geolocation', function () {
     expect(results).toEqual(geolocation_msgs['errors.location.timeout']);
   });
 
+});
+
+describe('Geolocation unsupported', function () {
+
+  // load the service's module
+  beforeEach(module('geolocation'));
+
+  beforeEach(function() {
+    module(function ($provide) {
+        $provide.value('$window', {
+            navigator: false
+        });
+    });
+  });
+
+  it('should not obtain user location due to missing geolocation', inject(function ($rootScope, geolocation, geolocation_msgs) {
+    var results;
+    spyOn($rootScope, '$broadcast');
+    geolocation.getLocation().then(function(){},function(error) {
+      results = error;
+    });
+    $rootScope.$digest();
+    expect($rootScope.$broadcast).toHaveBeenCalledWith('error',geolocation_msgs['errors.location.unsupportedBrowser']);
+    expect(results).toEqual(geolocation_msgs['errors.location.unsupportedBrowser']);
+  }));
 });


### PR DESCRIPTION
If browser doesn't support navigator then angular invokes reject already inside `$digest`, so it throws error `$apply already in progress`.

Test didn't work because `$window.navigator = {geolocation:false};` didn't change `$window`, I've mocked it in $window provider.
